### PR TITLE
Disable logging by default because .env configuration is required

### DIFF
--- a/config/remote-logging.php
+++ b/config/remote-logging.php
@@ -5,7 +5,7 @@ return [
 	/*
      * Determine if remote logging should be enabled.
      */
-    'enabled' => env('REMOTELOGGING_ENABLED', true),
+    'enabled' => env('REMOTELOGGING_ENABLED', false),
 
     /*
      * Specify the Autorization Bearer token that will be used for remote logging.


### PR DESCRIPTION
Otherwise the whole development team needs to update there local .env file